### PR TITLE
Bs5

### DIFF
--- a/.github/workflows/php-test-master.yml
+++ b/.github/workflows/php-test-master.yml
@@ -1,7 +1,8 @@
 name: PHP Codeception Tests - master
 
 on:
-  push:
+  #push:
+  workflow_dispatch:
 
 jobs:
   tests:

--- a/Events.php
+++ b/Events.php
@@ -37,7 +37,7 @@ class Events
 
         $menu->addEntry(new MenuLink([
             'label' => Yii::t('ReportcontentModule.base', 'Report'),
-            'icon' => 'fa-exclamation-triangle',
+            'icon' => 'exclamation-triangle',
             'url' => '#',
             'htmlOptions' => [
                 'data-action-click' => 'ui.modal.load',
@@ -57,7 +57,7 @@ class Events
             'label' => Yii::t('ReportcontentModule.base', 'Reported Content') . self::getReportsCountBadge(),
             'url' => Url::to(['/reportcontent/admin']),
             'group' => 'manage',
-            'icon' => '<i class="fa fa-exclamation-triangle"></i>',
+            'icon' => 'exclamation-triangle',
             'isActive' => (Yii::$app->controller->module && Yii::$app->controller->module->id == 'reportcontent' && Yii::$app->controller->id == 'admin'),
             'sortOrder' => 510,
         ]);
@@ -73,7 +73,7 @@ class Events
                 'label' => Yii::t('ReportcontentModule.base', 'Reported Content') . self::getReportsCountBadge($space),
                 'url' => $space->createUrl('/reportcontent/space-admin'),
                 'group' => 'admin',
-                'icon' => '<i class="fa fa-exclamation-triangle"></i>',
+                'icon' => 'exclamation-triangle',
                 'isActive' => (Yii::$app->controller->module && Yii::$app->controller->module->id == 'reportcontent' && Yii::$app->controller->id == 'space-admin'),
                 'sortOrder' => 510,
             ]);

--- a/Events.php
+++ b/Events.php
@@ -10,6 +10,7 @@ use humhub\modules\reportcontent\helpers\Permission;
 use humhub\modules\reportcontent\models\ReportContent;
 use humhub\modules\space\models\Space;
 use humhub\modules\ui\menu\MenuLink;
+use humhub\widgets\bootstrap\Badge;
 use yii\db\AfterSaveEvent;
 use yii\db\Expression;
 use yii\helpers\Url;
@@ -214,7 +215,7 @@ class Events
         $reportsCount = ReportContent::find()->readable($container)->count();
 
         return $reportsCount > 0
-            ? '&nbsp;&nbsp;<span class="label label-danger">' . $reportsCount . '</span>'
+            ? '&nbsp;&nbsp;' . Badge::danger($reportsCount)
             : '';
     }
 }

--- a/Events.php
+++ b/Events.php
@@ -215,7 +215,7 @@ class Events
         $reportsCount = ReportContent::find()->readable($container)->count();
 
         return $reportsCount > 0
-            ? '&nbsp;&nbsp;' . Badge::danger($reportsCount)
+            ? Badge::danger($reportsCount)->cssClass('ms-1')
             : '';
     }
 }

--- a/components/ActiveQueryReportContent.php
+++ b/components/ActiveQueryReportContent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://www.humhub.org/
  * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG

--- a/controllers/ReportController.php
+++ b/controllers/ReportController.php
@@ -3,7 +3,7 @@
 namespace humhub\modules\reportcontent\controllers;
 
 use humhub\modules\reportcontent\models\ReportContent;
-use humhub\widgets\ModalClose;
+use humhub\widgets\modal\ModalClose;
 use Yii;
 use yii\helpers\Url;
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-1.2.0 (unreleased)
--------------------------
+1.2.0 (July 26, 2025)
+---------------------
 - Enh #84: Migration to Bootstrap 5 for HumHub 1.18
 - Enh #82: Set notification category "Administrative"
 - Enh #83: Use PHP CS Fixer

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,9 @@
 Changelog
 =========
 
-1.1.1 (Unreleased)
-----------------------
+1.2.0 (unreleased)
+-------------------------
+- Enh #84: Migration to Bootstrap 5 for HumHub 1.18
 - Enh #82: Set notification category "Administrative"
 - Enh #83: Use PHP CS Fixer
 

--- a/helpers/Permission.php
+++ b/helpers/Permission.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://www.humhub.org/
  * @copyright Copyright (c) HumHub GmbH & Co. KG

--- a/models/ReportContent.php
+++ b/models/ReportContent.php
@@ -4,15 +4,15 @@ namespace humhub\modules\reportcontent\models;
 
 use humhub\components\ActiveRecord;
 use humhub\modules\comment\models\Comment;
+use humhub\modules\content\models\Content;
 use humhub\modules\content\permissions\ManageContent;
 use humhub\modules\reportcontent\components\ActiveQueryReportContent;
 use humhub\modules\reportcontent\helpers\Permission;
 use humhub\modules\reportcontent\notifications\NewReportAdmin;
 use humhub\modules\space\models\Membership;
-use humhub\modules\user\models\Group;
 use humhub\modules\space\models\Space;
+use humhub\modules\user\models\Group;
 use humhub\modules\user\models\User;
-use humhub\modules\content\models\Content;
 use Yii;
 use yii\base\InvalidArgumentException;
 

--- a/module.json
+++ b/module.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/humhub/reportcontent",
   "license": "AGPL-3.0-or-later",
   "humhub": {
-    "minVersion": "1.18.0"
+    "minVersion": "1.18"
   },
   "screenshots": ["resources/screen1.PNG", "resources/screen2.PNG", "resources/screen3.PNG", "resources/screen4.PNG", "resources/screen5.PNG"]
 }

--- a/module.json
+++ b/module.json
@@ -9,7 +9,7 @@
     "profanity filter",
     "abuse"
   ],
-  "version": "1.1.1",
+  "version": "1.2.0",
   "authors": [
     {
       "name": "HumHub Staff"

--- a/module.json
+++ b/module.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/humhub/reportcontent",
   "license": "AGPL-3.0-or-later",
   "humhub": {
-    "minVersion": "1.14"
+    "minVersion": "1.18.0"
   },
   "screenshots": ["resources/screen1.PNG", "resources/screen2.PNG", "resources/screen3.PNG", "resources/screen4.PNG", "resources/screen5.PNG"]
 }

--- a/notifications/NewReportAdmin.php
+++ b/notifications/NewReportAdmin.php
@@ -15,8 +15,8 @@ use humhub\modules\content\models\Content;
 use humhub\modules\notification\components\BaseNotification;
 use humhub\modules\reportcontent\models\ReportContent;
 use humhub\modules\space\models\Space;
+use humhub\helpers\Html;
 use Yii;
-use yii\helpers\Html;
 use yii\helpers\Url;
 
 /**

--- a/services/PermissionService.php
+++ b/services/PermissionService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://www.humhub.org/
  * @copyright Copyright (c) HumHub GmbH & Co. KG

--- a/tests/codeception.yml
+++ b/tests/codeception.yml
@@ -20,7 +20,7 @@ settings:
     backup_globals: true
 paths:
     tests: codeception
-    log: codeception/_output
+    output: codeception/_output
     data: codeception/_data
     helpers: codeception/_support
     envs: ../../../humhub/tests/config/env
@@ -28,4 +28,3 @@ config:
     # the entry script URL (with host info) for functional and acceptance tests
     # PLEASE ADJUST IT TO THE ACTUAL ENTRY SCRIPT URL
     test_entry_url: http://localhost:8080/index-test.php
-    

--- a/tests/codeception/_bootstrap.php
+++ b/tests/codeception/_bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://www.humhub.org/
  * @copyright Copyright (c) 2015 HumHub GmbH & Co. KG

--- a/tests/codeception/acceptance.suite.yml
+++ b/tests/codeception/acceptance.suite.yml
@@ -8,7 +8,7 @@
 
 # RUN `build` COMMAND AFTER ADDING/REMOVING MODULES.
 
-class_name: AcceptanceTester
+actor: AcceptanceTester
 modules:
     enabled:
         #- PhpBrowser

--- a/tests/codeception/acceptance/ReportCommentCest.php
+++ b/tests/codeception/acceptance/ReportCommentCest.php
@@ -25,7 +25,7 @@ class ReportCommentCest
         $I->wait(1);
         $I->moveMouseOver('#comment-message-1');
         $I->wait(1);
-        $I->click('.fa.fa-angle-down', '#comment_1');
+        $I->click('a.nav-link.dropdown-toggle', '#comment_1');
         $I->wait(1);
         $I->click('Report', '#comment_1');
         $I->waitForElementVisible('#reportcontent-reason');

--- a/tests/codeception/acceptance/ReportContentCest.php
+++ b/tests/codeception/acceptance/ReportContentCest.php
@@ -50,13 +50,13 @@ class ReportContentCest
 
         $I->expectTo('see a report notification');
         $I->waitForText('Reported Content');
-        $I->seeElement('a[data-original-title="Review"]');
+        $I->seeElement('a[data-bs-title="Review"]');
 
         /**
          * Delete Reported Post as Admin
          */
         $I->amGoingTo('delete the post after review');
-        $I->jsClick('a[data-original-title="Review"]');
+        $I->jsClick('a[data-bs-title="Review"]');
         $I->waitForElement('.dropdown-toggle[aria-label="Toggle stream entry menu"]');
         $I->jsClick('.dropdown-toggle[aria-label="Toggle stream entry menu"]');
         $I->click('Delete');
@@ -110,10 +110,10 @@ class ReportContentCest
 
         $I->expectTo('see a report notification');
         $I->waitForText('Reported Content');
-        $I->seeElement('a[data-original-title="Approve"]');
+        $I->seeElement('a[data-bs-title="Approve"]');
 
         $I->amGoingTo('approve the post in report view');
-        $I->jsClick('a[data-original-title="Approve"]');
+        $I->jsClick('a[data-bs-title="Approve"]');
         //$I->waitForText('Do you really want to approve this post?');
         //$I->jsClick('.modalConfirm:visible');
 
@@ -181,11 +181,11 @@ class ReportContentCest
 
         $I->waitForText('This overview shows you a list of content that has been reported for various reasons.');
 
-        $I->seeElement('a[data-original-title="Approve"]');
-        $I->seeElement('a[data-original-title="Review"]');
+        $I->seeElement('a[data-bs-title="Approve"]');
+        $I->seeElement('a[data-bs-title="Review"]');
 
         $I->amGoingTo('approve the reported post');
-        $I->click('a[data-original-title="Approve"]');
+        $I->click('a[data-bs-title="Approve"]');
         $I->wait(5);
 
         $I->expect('not to see the report');
@@ -232,11 +232,11 @@ class ReportContentCest
         $I->amOnRoute(['/reportcontent/admin']);
 
         $I->expectTo('see a report notification');
-        $I->seeElement('a[data-original-title="Approve"]');
-        $I->seeElement('a[data-original-title="Review"]');
+        $I->seeElement('a[data-bs-title="Approve"]');
+        $I->seeElement('a[data-bs-title="Review"]');
 
         $I->amGoingTo('delete the post after review');
-        $I->jsClick('a[data-original-title="Review"]');
+        $I->jsClick('a[data-bs-title="Review"]');
         $I->waitForText('Some bad words');
         $I->wait(2);
         $I->jsClick('.dropdown-toggle[aria-label="Toggle stream entry menu"]');

--- a/tests/codeception/functional.suite.yml
+++ b/tests/codeception/functional.suite.yml
@@ -5,7 +5,7 @@
 # (tip: better to use with frameworks).
 
 # RUN `build` COMMAND AFTER ADDING/REMOVING MODULES.
-class_name: FunctionalTester
+actor: FunctionalTester
 modules:
     enabled:
       - Filesystem

--- a/tests/codeception/functional/_bootstrap.php
+++ b/tests/codeception/functional/_bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Initialize the HumHub Application for functional testing. The default application configuration for this suite can be overwritten
  * in @tests/config/functional.php

--- a/tests/codeception/unit.suite.yml
+++ b/tests/codeception/unit.suite.yml
@@ -3,7 +3,7 @@
 # suite for unit (internal) tests.
 # RUN `build` COMMAND AFTER ADDING/REMOVING MODULES.
 
-class_name: UnitTester
+actor: UnitTester
 modules:
     enabled:
         - tests\codeception\_support\CodeHelper

--- a/tests/codeception/unit/_bootstrap.php
+++ b/tests/codeception/unit/_bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * The bootstrapping of unit tests is done by yii\codeception\DbTestCase or tests\codeception\_support\HumHubDbTestCase
  * These classes will automatically load the config from @tests/codeception/config/unit.php

--- a/tests/config/api.php
+++ b/tests/config/api.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Here you can overwrite your functional humhub config. The default config resiedes in @humhubTests/codeception/config/config.php
  */

--- a/tests/config/common.php
+++ b/tests/config/common.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This config is shared by all suites (unit/functional/acceptance) and can be overwritten by a suite config (e.g. functional.php)
  */

--- a/tests/config/functional.php
+++ b/tests/config/functional.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Here you can overwrite the default config for the functional suite. The default config resides in @humhubTests/codeception/config/config.php
  */

--- a/tests/config/unit.php
+++ b/tests/config/unit.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Here you can overwrite your functional humhub config. The default config resiedes in @humhubTests/codeception/config/config.php
  */

--- a/views/admin/configuration.php
+++ b/views/admin/configuration.php
@@ -1,18 +1,18 @@
 <?php
-/* @var $this \humhub\modules\ui\view\components\View */
+/* @var $this \humhub\components\View */
 /* @var $model \humhub\modules\reportcontent\models\Configuration */
 
-use humhub\modules\ui\form\widgets\ActiveForm;
+use humhub\widgets\form\ActiveForm;
 use humhub\modules\ui\icon\widgets\Icon;
-use humhub\libs\Html;
-use humhub\widgets\Button;
+use humhub\helpers\Html;
+use humhub\widgets\bootstrap\Button;
 
 ?>
 <div class="panel panel-default">
     <div class="panel-heading">
         <?= Button::asLink(Icon::get('back'))
             ->link(['index'])
-            ->cssClass('pull-right btn btn-default')
+            ->cssClass('float-end btn btn-light')
             ->tooltip(Yii::t('AdminModule.base', 'Settings')) ?>
 
         <?= Yii::t('ReportcontentModule.base', '<strong>Report</strong> Content'); ?>
@@ -22,7 +22,7 @@ use humhub\widgets\Button;
         <?= $form->field($model, 'profanityFilterList')->textarea(['rows' => 10]); ?>
         <?= $form->field($model, 'blockContributions')->checkbox(); ?>
         <br/>
-        <div class="form-group">
+        <div class="mb-3">
             <?= Html::submitButton(Yii::t('base', 'Save'), ['class' => 'btn btn-primary', 'data-ui-loader' => '']) ?>
         </div>
         <?php ActiveForm::end(); ?>

--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -6,9 +6,10 @@
 /* @var $pagination \yii\data\Pagination */
 
 use humhub\modules\ui\icon\widgets\Icon;
-use humhub\widgets\Button;
+use humhub\widgets\bootstrap\Button;
 
 ?>
+
 <div class="panel panel-default">
     <div class="panel-heading">
         <?= Button::asLink(Icon::get('cog'))

--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -1,6 +1,6 @@
 <?php
 
-/* @var $this \humhub\modules\ui\view\components\View */
+/* @var $this \humhub\components\View */
 /* @var $reportedContent \humhub\modules\reportcontent\models\ReportContent[] */
 
 /* @var $pagination \yii\data\Pagination */
@@ -13,7 +13,7 @@ use humhub\widgets\Button;
     <div class="panel-heading">
         <?= Button::asLink(Icon::get('cog'))
             ->link(['configuration'])
-            ->cssClass('pull-right btn btn-default')
+            ->cssClass('float-end btn btn-light')
             ->tooltip(Yii::t('AdminModule.base', 'Settings')) ?>
 
         <?= Yii::t('ReportcontentModule.base', '<strong>Reported</strong> Content') ?>

--- a/views/report/index.php
+++ b/views/report/index.php
@@ -14,7 +14,7 @@ use humhub\widgets\modal\ModalButton;
 
 <?php $form = Modal::beginFormDialog([
     'title' => Yii::t('ReportcontentModule.base', '<strong>Report</strong> Content'),
-    'footer' => ModalButton::cancel() . ModalButton::save(Yii::t('ReportcontentModule.base', 'Send')),
+    'footer' => ModalButton::cancel() . ModalButton::save(Yii::t('ReportcontentModule.base', 'Send'))->submit(),
     'form' => ['id' => 'report-content-form'],
 ]); ?>
     <?= $form->field($model, 'content_id')->hiddenInput()->label(false) ?>

--- a/views/report/index.php
+++ b/views/report/index.php
@@ -18,9 +18,7 @@ use humhub\widgets\modal\Modal;
         'footer' => ModalButton::cancel() . ModalButton::save(Yii::t('ReportcontentModule.base', 'Send')),
         'form' => ['id' => 'report-content-form'],
     ]); ?>
-<div class="modal-body">
     <?= $form->field($model, 'content_id')->hiddenInput()->label(false); ?>
     <?= $form->field($model, 'comment_id')->hiddenInput()->label(false); ?>
     <?= $form->field($model, 'reason')->radioList($model->getReasons(true)); ?>
-</div>
 <?php Modal::endFormDialog(); ?>

--- a/views/report/index.php
+++ b/views/report/index.php
@@ -1,9 +1,9 @@
 <?php
 
 use humhub\modules\reportcontent\models\ReportContent;
-use humhub\modules\ui\form\widgets\ActiveForm;
-use humhub\widgets\ModalButton;
-use humhub\widgets\ModalDialog;
+use humhub\widgets\form\ActiveForm;
+use humhub\widgets\modal\ModalButton;
+use humhub\widgets\modal\Modal;
 
 /**
  * @var $content \humhub\modules\content\models\Content
@@ -13,16 +13,14 @@ use humhub\widgets\ModalDialog;
 
 ?>
 
-<?php ModalDialog::begin(['header' => Yii::t('ReportcontentModule.base', '<strong>Report</strong> Content')]); ?>
-<?php $form = ActiveForm::begin(['id' => 'report-content-form']); ?>
+<?php $form = Modal::beginFormDialog([
+        'title' => Yii::t('ReportcontentModule.base', '<strong>Report</strong> Content'),
+        'footer' => ModalButton::cancel() . ModalButton::save(Yii::t('ReportcontentModule.base', 'Send')),
+        'form' => ['id' => 'report-content-form'],
+    ]); ?>
 <div class="modal-body">
     <?= $form->field($model, 'content_id')->hiddenInput()->label(false); ?>
     <?= $form->field($model, 'comment_id')->hiddenInput()->label(false); ?>
     <?= $form->field($model, 'reason')->radioList($model->getReasons(true)); ?>
 </div>
-<div class="modal-footer">
-    <?= ModalButton::submitModal(null, Yii::t('ReportcontentModule.base', 'Send')) ?>
-    <?= ModalButton::cancel() ?>
-</div>
-<?php ActiveForm::end() ?>
-<?php ModalDialog::end(); ?>
+<?php Modal::endFormDialog(); ?>

--- a/views/report/index.php
+++ b/views/report/index.php
@@ -1,9 +1,8 @@
 <?php
 
 use humhub\modules\reportcontent\models\ReportContent;
-use humhub\widgets\form\ActiveForm;
-use humhub\widgets\modal\ModalButton;
 use humhub\widgets\modal\Modal;
+use humhub\widgets\modal\ModalButton;
 
 /**
  * @var $content \humhub\modules\content\models\Content
@@ -14,11 +13,11 @@ use humhub\widgets\modal\Modal;
 ?>
 
 <?php $form = Modal::beginFormDialog([
-        'title' => Yii::t('ReportcontentModule.base', '<strong>Report</strong> Content'),
-        'footer' => ModalButton::cancel() . ModalButton::save(Yii::t('ReportcontentModule.base', 'Send')),
-        'form' => ['id' => 'report-content-form'],
-    ]); ?>
-    <?= $form->field($model, 'content_id')->hiddenInput()->label(false); ?>
-    <?= $form->field($model, 'comment_id')->hiddenInput()->label(false); ?>
-    <?= $form->field($model, 'reason')->radioList($model->getReasons(true)); ?>
+    'title' => Yii::t('ReportcontentModule.base', '<strong>Report</strong> Content'),
+    'footer' => ModalButton::cancel() . ModalButton::save(Yii::t('ReportcontentModule.base', 'Send')),
+    'form' => ['id' => 'report-content-form'],
+]); ?>
+    <?= $form->field($model, 'content_id')->hiddenInput()->label(false) ?>
+    <?= $form->field($model, 'comment_id')->hiddenInput()->label(false) ?>
+    <?= $form->field($model, 'reason')->radioList($model->getReasons(true)) ?>
 <?php Modal::endFormDialog(); ?>

--- a/views/reportContentAdminGrid.php
+++ b/views/reportContentAdminGrid.php
@@ -9,6 +9,7 @@ use humhub\helpers\Html;
 use humhub\modules\user\widgets\Image as UserImage;
 use humhub\widgets\GridView;
 use humhub\widgets\bootstrap\Alert;
+use humhub\widgets\bootstrap\Button;
 use yii\data\ArrayDataProvider;
 use yii\grid\DataColumn;
 
@@ -81,16 +82,18 @@ use yii\grid\DataColumn;
                 'format' => 'raw',
                 'options' => ['style' => 'width:85px;'],
                 'value' => function ($report) use ($isAdmin) {
-                    $approve = Html::a(
-                        '<i class="fa fa-check-square-o"></i>', ['/reportcontent/report/appropriate', 'id' => $report->id, 'admin' => $isAdmin],
-                        ['data-method' => 'POST', 'class' => 'btn btn-success btn-sm tt', 'data-original-title' => 'Approve']
-                    );
+                    $approve = Button::success()
+                        ->icon('check-square-o')
+                        ->link(['/reportcontent/report/appropriate', 'id' => $report->id, 'admin' => $isAdmin])
+                        ->options(['data-method' => 'POST'])
+                        ->sm()
+                        ->tooltip(Yii::t('ReportcontentModule.base', 'Approve'));
 
-                    $review = Html::a('<i aria-hidden="true" class="fa fa-eye"></i>', $report->content->getUrl(), [
-                        'class' => 'btn btn-sm btn-primary tt',
-                        'title' => Yii::t('ReportcontentModule.base', 'Review'),
-                        'data-ui-loader' => '1'
-                    ]);
+                    $review = Button::primary()
+                        ->icon('eye')
+                        ->link($report->content->getUrl())
+                        ->sm()
+                        ->tooltip(Yii::t('ReportcontentModule.base', 'Review'));
 
                     return $approve . ' ' . $review;
                 }

--- a/views/reportContentAdminGrid.php
+++ b/views/reportContentAdminGrid.php
@@ -5,9 +5,10 @@ use humhub\modules\content\components\ContentActiveRecord;
 use humhub\modules\content\models\Content;
 use humhub\modules\content\widgets\richtext\converter\RichTextToShortTextConverter;
 use humhub\modules\reportcontent\models\ReportContent;
-use humhub\libs\Html;
+use humhub\helpers\Html;
 use humhub\modules\user\widgets\Image as UserImage;
 use humhub\widgets\GridView;
+use humhub\widgets\bootstrap\Alert;
 use yii\data\ArrayDataProvider;
 use yii\grid\DataColumn;
 
@@ -17,10 +18,7 @@ use yii\grid\DataColumn;
 ?>
 
 <?php if (empty($reportedContent)) : ?>
-    <br/>
-    <p class="alert alert-success">
-        <?= Yii::t('ReportcontentModule.base', 'There is no content reported for review.') ?>
-    </p>
+    <?= Alert::success(Yii::t('ReportcontentModule.base', 'There is no content reported for review.')) ?>
 <?php else : ?>
     <?= GridView::widget([
         'dataProvider' => new ArrayDataProvider(['allModels' => $reportedContent]),

--- a/views/space-admin/index.php
+++ b/views/space-admin/index.php
@@ -1,6 +1,6 @@
 <?php
 
-/* @var $this \humhub\modules\ui\view\components\View */
+/* @var $this \humhub\components\View */
 /* @var $reportedContent \humhub\modules\reportcontent\models\ReportContent[] */
 /* @var $pagination \yii\data\Pagination */
 

--- a/widgets/ReportContentLink.php
+++ b/widgets/ReportContentLink.php
@@ -28,7 +28,7 @@ class ReportContentLink extends Widget
             return Html::tag(
                 'li',
                 Html::a(
-                    Icon::get('exclamation-triangle'). ' ' . Yii::t('ReportcontentModule.base', 'Report'),
+                    Icon::get('exclamation-triangle') . ' ' . Yii::t('ReportcontentModule.base', 'Report'),
                     '#',
                     ['data-action-click' => 'ui.modal.load', 'data-action-click-url' => $reportUrl],
                 ),

--- a/widgets/ReportContentLink.php
+++ b/widgets/ReportContentLink.php
@@ -3,7 +3,7 @@
 namespace humhub\modules\reportcontent\widgets;
 
 use humhub\components\Widget;
-use humhub\libs\Html;
+use humhub\helpers\Html;
 use humhub\modules\reportcontent\helpers\Permission;
 use humhub\modules\content\components\ContentActiveRecord;
 use Yii;

--- a/widgets/ReportContentLink.php
+++ b/widgets/ReportContentLink.php
@@ -6,6 +6,7 @@ use humhub\components\Widget;
 use humhub\helpers\Html;
 use humhub\modules\reportcontent\helpers\Permission;
 use humhub\modules\content\components\ContentActiveRecord;
+use humhub\modules\ui\icon\widgets\Icon;
 use Yii;
 use yii\helpers\Url;
 
@@ -26,9 +27,9 @@ class ReportContentLink extends Widget
 
             return Html::tag(
                 'li',
-                Html::tag(
-                    'a',
-                    '<i class="fa fa-exclamation-circle"></i>' . Yii::t('ReportcontentModule.base', 'Report'),
+                Html::a(
+                    Icon::get('exclamation-triangle'). ' ' . Yii::t('ReportcontentModule.base', 'Report'),
+                    '#',
                     ['data-action-click' => 'ui.modal.load', 'data-action-click-url' => $reportUrl],
                 ),
             );


### PR DESCRIPTION
- [x] validation error of radioList not visible (if no reason was selected when reporting a content)
@marc-farre I leave this validation message issue again to you, ok?
The field is generated like this:
```
<?= $form->field($model, 'reason')->radioList($model->getReasons(true)); ?>
```
----

I changed the used icon to 'exclamation-triangle' everywhere. Before, 'exclamation-circle' was used in wall entry controls but everywhere else, even in the comment control menu, the triangle was used.