### PR TITLE
Use RichTextToShortHtmlConverter for admin grid preview

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 1.3.0 (Unreleased)
 -----------------------
 - Enh #101: Update for HumHub 1.19
+- Fix: Use `RichTextToShortHtmlConverter` for the report admin grid preview (the core `RichTextToShortTextConverter` now returns unencoded plain text — see humhub/humhub#8181)
 
 1.2.1 (Februrary 27, 2026)
 --------------------------

--- a/views/reportContentAdminGrid.php
+++ b/views/reportContentAdminGrid.php
@@ -3,7 +3,7 @@
 use humhub\modules\comment\models\Comment;
 use humhub\modules\content\components\ContentActiveRecord;
 use humhub\modules\content\models\Content;
-use humhub\modules\content\widgets\richtext\converter\RichTextToShortTextConverter;
+use humhub\modules\content\widgets\richtext\converter\RichTextToShortHtmlConverter;
 use humhub\modules\reportcontent\models\ReportContent;
 use humhub\helpers\Html;
 use humhub\modules\user\widgets\Image as UserImage;
@@ -45,9 +45,9 @@ use yii\grid\DataColumn;
 
                     $result = Html::beginTag('p');
                     $result .= Html::encode($reportedRecord->getContentName()) . ': ';
-                    $result .= RichTextToShortTextConverter::process(
+                    $result .= RichTextToShortHtmlConverter::process(
                         $reportedRecord->getContentDescription(),
-                        [RichTextToShortTextConverter::OPTION_MAX_LENGTH => 200]
+                        [RichTextToShortHtmlConverter::OPTION_MAX_LENGTH => 200]
                     );
                     $result .= Html::endTag('p');
 


### PR DESCRIPTION
## Summary

Companion to humhub/humhub#8181, which splits the core short text converter into a plain text variant (`RichTextToShortTextConverter`) and a new encoded variant (`RichTextToShortHtmlConverter`).

`views/reportContentAdminGrid.php` renders the report description inside a `format: 'raw'` column. After the core change it would emit unencoded text there — an admin XSS via reported content titles/bodies. Switching to the new `RichTextToShortHtmlConverter` keeps the output HTML-safe (same behavior the module relied on before).

`humhub.minVersion` is already at `1.19` on develop, so no further bump is needed.

## Test plan

- [ ] Local: install develop alongside humhub/humhub#8181, create a report on content whose body contains `<` / `&`, confirm the admin grid renders the encoded entities (not raw HTML)